### PR TITLE
Sorting by generatedDate instead of UUID

### DIFF
--- a/src/main/kotlin/no/nav/tsm/mottak/controllers/model/SykmeldingBuilder.kt
+++ b/src/main/kotlin/no/nav/tsm/mottak/controllers/model/SykmeldingBuilder.kt
@@ -14,7 +14,6 @@ val sykmeldingMedBehandlingsutfall = SykmeldingMedBehandlingsutfall(
             partnerreferanse = null,
             avsenderSystem = AvsenderSystem("", ""),
             mottattDato = OffsetDateTime.now(),
-            genDate = OffsetDateTime.now(),
             behandletTidspunkt = OffsetDateTime.now(),
         ),
         pasient = Person(ident = "", navn = null),
@@ -30,7 +29,8 @@ val sykmeldingMedBehandlingsutfall = SykmeldingMedBehandlingsutfall(
         bistandNav = null,
         tilbakedatering = null,
         aktivitet = listOf(AktivitetIkkeMulig(medisinskArsak = MedisinskArsak(null, MedisinskArsakType.ANNET), null, fom = 1.januar(2023), tom = 31.januar(2023))),
-        utdypendeOpplysninger = emptyMap()
+        utdypendeOpplysninger = emptyMap(),
+        generatedDate = OffsetDateTime.now()
         ),
     validation = ValidationResult(
         status = RuleType.OK,

--- a/src/main/kotlin/no/nav/tsm/mottak/db/SykmeldingBehandlingsutfall.kt
+++ b/src/main/kotlin/no/nav/tsm/mottak/db/SykmeldingBehandlingsutfall.kt
@@ -4,6 +4,7 @@ import org.springframework.data.relational.core.mapping.Table
 
 
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 @Table("sykmelding_behandlingsutfall")
 data class SykmeldingBehandlingsutfall (
@@ -11,6 +12,7 @@ data class SykmeldingBehandlingsutfall (
     val pasientIdent: String,
     val fom: LocalDate,
     val tom: LocalDate,
+    val generatedDate: OffsetDateTime?,
     val sykmelding: Json,
     val metadata: Json,
     val kilde: String,

--- a/src/main/kotlin/no/nav/tsm/mottak/db/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/tsm/mottak/db/SykmeldingMapper.kt
@@ -17,6 +17,7 @@ class SykmeldingMapper {
             pasientIdent = sykmeldingMedBehandlingsutfall.sykmelding.pasient.ident,
             fom = sykmeldingMedBehandlingsutfall.sykmelding.aktivitet.first().fom,
             tom = sykmeldingMedBehandlingsutfall.sykmelding.aktivitet.last().tom,
+            generatedDate = sykmeldingMedBehandlingsutfall.sykmelding.generatedDate,
             sykmelding = Json.of(objectMapper.writeValueAsString(sykmeldingMedBehandlingsutfall.sykmelding)),
             metadata = Json.of(objectMapper.writeValueAsString(sykmeldingMedBehandlingsutfall.sykmelding.metadata)),
             kilde = sykmeldingMedBehandlingsutfall.kilde.name,

--- a/src/main/kotlin/no/nav/tsm/mottak/db/SykmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/tsm/mottak/db/SykmeldingRepository.kt
@@ -10,4 +10,6 @@ interface SykmeldingRepository : CoroutineCrudRepository<SykmeldingBehandlingsut
 
     fun findTop10ByOrderBySykmeldingIdDesc(): Flow<SykmeldingBehandlingsutfall>
 
+    fun findTop10ByOrderByGeneratedDateDesc(): Flow<SykmeldingBehandlingsutfall>
+
 }

--- a/src/main/kotlin/no/nav/tsm/mottak/service/SykmeldingService.kt
+++ b/src/main/kotlin/no/nav/tsm/mottak/service/SykmeldingService.kt
@@ -20,7 +20,7 @@ class SykmeldingService(
     }
 
     suspend fun getLatestSykmeldinger(): List<SykmeldingBehandlingsutfall> {
-        return sykmeldingRepository.findTop10ByOrderBySykmeldingIdDesc().toList()
+        return sykmeldingRepository.findTop10ByOrderByGeneratedDateDesc().toList()
 
     }
 }

--- a/src/main/kotlin/no/nav/tsm/mottak/sykmelding/kafka/model/Sykmelding.kt
+++ b/src/main/kotlin/no/nav/tsm/mottak/sykmelding/kafka/model/Sykmelding.kt
@@ -14,6 +14,7 @@ enum class SykmeldingKilde {
 data class Sykmelding(
     val id: String,
     val metadata: SykmeldingMetadata,
+    val generatedDate: OffsetDateTime,
     val pasient: Person,
     val behandler: Behandler,
     val arbeidsgiver: ArbeidsgiverInfo,
@@ -32,7 +33,6 @@ data class SykmeldingMetadata(
     val partnerreferanse: String?,
     val avsenderSystem: AvsenderSystem,
     val mottattDato: OffsetDateTime,
-    val genDate: OffsetDateTime, // Todo endre navn?
     val behandletTidspunkt: OffsetDateTime,
 )
 

--- a/src/main/resources/db/migration/V2__add_column_generated_date.sql
+++ b/src/main/resources/db/migration/V2__add_column_generated_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sykmelding_behandlingsutfall ADD COLUMN generated_date DATE;

--- a/src/main/resources/db/migration/V3__modify_column_generated_date.sql
+++ b/src/main/resources/db/migration/V3__modify_column_generated_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sykmelding_behandlingsutfall ALTER COLUMN generated_date TYPE timestamp WITH TIME ZONE;


### PR DESCRIPTION
Styrer på med sortering av sykmelding på dato i stedet for ID. Litt omgruppering av generatedDate i basen for å gjøre det letter for Spring å hente ut dataene